### PR TITLE
FindOpenCV: Fix arguments passed to find_package_handle_standard_args

### DIFF
--- a/find-modules/FindOpenCV.cmake
+++ b/find-modules/FindOpenCV.cmake
@@ -96,7 +96,7 @@ if(OpenCV_FOUND)
     endif()
 endif()
 
-find_package_handle_standard_args(OpenCV DEFAULT_MSG OpenCV_CONFIG)
+find_package_handle_standard_args(OpenCV REQUIRED_VARS OpenCV_FOUND CONFIG_MODE)
 
 if(COMMAND set_package_properties)
     set_package_properties(OpenCV PROPERTIES DESCRIPTION "Open source computer vision library"


### PR DESCRIPTION
`OpenCV_CONFIG` is not a variable set, so I have no idea why this was working without giving an error:

~~~
 Could NOT find OpenCV (missing: OpenCV_CONFIG)
~~~

as it is happening in https://github.com/icub-tech-iit/ergocub-software/issues/248 .