### PR TITLE
Remove FindMatlab tests as FindMatlab is not part of ycm

### DIFF
--- a/tests/RunCMake/cmake-next/RunCMakeTest.cmake
+++ b/tests/RunCMake/cmake-next/RunCMakeTest.cmake
@@ -2,7 +2,6 @@ include(RunCMake)
 
 run_cmake(find_package_Doxygen)
 run_cmake(find_package_GLEW)
-run_cmake(find_package_Matlab)
 run_cmake(find_package_OpenGL)
 run_cmake(find_package_Python)
 run_cmake(find_package_Python2)

--- a/tests/RunCMake/cmake-next/find_package_Matlab.cmake
+++ b/tests/RunCMake/cmake-next/find_package_Matlab.cmake
@@ -1,1 +1,0 @@
-find_package(Matlab QUIET)


### PR DESCRIPTION
Fix https://github.com/robotology/ycm-cmake-modules/issues/450 .