### PR TITLE
Permit to use FetchContent_MakeAvailable when YCM is used via FetchContent and other related changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/internal-modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 
+include(YCMVersion)
 include(YCMInternal)
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 
 cmake_minimum_required(VERSION 3.16)
-project(YCM VERSION 0.16.10 LANGUAGES NONE)
+project(YCM VERSION 0.17.0 LANGUAGES NONE)
 
 # Check if the project is the main project or included via FetchContent
 if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,18 @@
 
 
 cmake_minimum_required(VERSION 3.16)
-project(YCM NONE)
+project(YCM VERSION 0.16.10 LANGUAGES NONE)
+
+# Check if the project is the main project or included via FetchContent
+if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    # Project is included via FetchContent
+    include(${CMAKE_CURRENT_SOURCE_DIR}/tools/UseYCMFromSource.cmake)
+    return()
+else()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/internal-modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 
-include(YCMVersion)
 include(YCMInternal)
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     # Project is included via FetchContent
     include(${CMAKE_CURRENT_SOURCE_DIR}/tools/UseYCMFromSource.cmake)
     return()
-else()
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/internal-modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules")

--- a/YCMConfig.cmake.in
+++ b/YCMConfig.cmake.in
@@ -1,18 +1,30 @@
 # SPDX-FileCopyrightText: 2012-2021 Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
+# A macro to print a warning when using deprecated variables, called by
+# variable_watch
+macro(_YCM_DEPRECATED_VARIABLE_WARNING _variable)
+  message(DEPRECATION "The ${_variable} variable is deprecated")
+endmacro()
 
 set(YCM_VERSION @YCM_VERSION@)
 set(YCM_VERSION_MAJOR @YCM_VERSION_MAJOR@)
 set(YCM_VERSION_MINOR @YCM_VERSION_MINOR@)
 set(YCM_VERSION_PATCH @YCM_VERSION_PATCH@)
 set(YCM_VERSION_REVISION @YCM_VERSION_REVISION@)
+variable_watch(YCM_VERSION_REVISION _ycm_deprecated_variable_warning)
 set(YCM_VERSION_DATE @YCM_VERSION_DATE@)
+variable_watch(YCM_VERSION_DATE _ycm_deprecated_variable_warning)
 set(YCM_VERSION_DATE_REVISION @YCM_VERSION_DATE_REVISION@)
+variable_watch(YCM_VERSION_DATE_REVISION _ycm_deprecated_variable_warning)
 set(YCM_VERSION_API @YCM_VERSION_API@)
+variable_watch(YCM_VERSION_API _ycm_deprecated_variable_warning)
 set(YCM_VERSION_SHORT @YCM_VERSION_SHORT@)
+variable_watch(YCM_VERSION_SHORT _ycm_deprecated_variable_warning)
 set(YCM_VERSION_SOURCE @YCM_VERSION_SOURCE@)
+variable_watch(YCM_VERSION_SOURCE _ycm_deprecated_variable_warning)
 set(YCM_VERSION_DIRTY @YCM_VERSION_DIRTY@)
+variable_watch(YCM_VERSION_DIRTY _ycm_deprecated_variable_warning)
 
 @PACKAGE_INIT@
 

--- a/internal-modules/YCMVersion.cmake
+++ b/internal-modules/YCMVersion.cmake
@@ -11,10 +11,7 @@ This module should not be used outside YCM.
 
 Variables defined by this module::
 
- YCM_VERSION          - Full version, including git commit and dirty state.
- YCM_VERSION_MAJOR    - YCM major version
- YCM_VERSION_MINOR    - YCM minor version
- YCM_VERSION_PATCH    - YCM patch version
+ YCM_VERSION_FULL     - Full version, including git commit and dirty state.
  YCM_VERSION_REVISION - Number of commits since latest release (git only)
  YCM_VERSION_DATE     - Date of the latest commit (git only)
  YCM_VERSION_DATE_REVISION - Number of commits since of beginning of the day
@@ -30,13 +27,8 @@ Variables defined by this module::
 
 include(GitInfo)
 
-set(YCM_VERSION_MAJOR 0)
-set(YCM_VERSION_MINOR 16)
-set(YCM_VERSION_PATCH 9)
-
 set(YCM_VERSION_API "${YCM_VERSION_MAJOR}.${YCM_VERSION_MINOR}")
 set(YCM_VERSION_SHORT "${YCM_VERSION_MAJOR}.${YCM_VERSION_MINOR}.${YCM_VERSION_PATCH}")
-set(YCM_VERSION "${YCM_VERSION_SHORT}")
 
 unset(YCM_VERSION_SOURCE)
 unset(YCM_VERSION_DIRTY)
@@ -73,14 +65,14 @@ if(DEFINED YCM_GIT_WT_HASH)
       string(APPEND YCM_VERSION_SHORT ".${YCM_VERSION_REVISION}")
     endif()
     set(YCM_VERSION_SOURCE "${_date}+git${YCM_GIT_WT_HASH_SHORT}")
-    set(YCM_VERSION "${YCM_VERSION_SHORT}-${YCM_VERSION_SOURCE}")
+    set(YCM_VERSION_FULL "${YCM_VERSION_SHORT}-${YCM_VERSION_SOURCE}")
   elseif(NOT "${YCM_GIT_WT_TAG}" STREQUAL "v${YCM_VERSION_SHORT}")
     # This is the same commit as the latest tag, but the version different
     # Probably some work in progress...
     # Add some random information.
     string(TIMESTAMP _ts "%Y%m%d")
     string(APPEND YCM_VERSION_SHORT "~${_ts}")
-    set(YCM_VERSION "${YCM_VERSION_SHORT}")
+    set(YCM_VERSION_FULL "${YCM_VERSION_SHORT}")
   else()
     # Same commit as latest tag.
     # Nothing to do
@@ -88,7 +80,7 @@ if(DEFINED YCM_GIT_WT_HASH)
   # Include information about the "dirty" status.
   if(YCM_GIT_WT_DIRTY)
     set(YCM_VERSION_DIRTY "dirty")
-    set(YCM_VERSION "${YCM_VERSION}+${YCM_VERSION_DIRTY}")
+    set(YCM_VERSION_FULL "${YCM_VERSION}+${YCM_VERSION_DIRTY}")
   endif()
 else()
   # This is not a git repository or git is missing.
@@ -97,7 +89,7 @@ else()
     # Add some random information.
     string(TIMESTAMP YCM_VERSION_PATCH "%Y%m%d")
     set(YCM_VERSION_SHORT "${YCM_VERSION_MAJOR}.${YCM_VERSION_MINOR}.${YCM_VERSION_PATCH}")
-    set(YCM_VERSION "${YCM_VERSION_SHORT}~dev")
+    set(YCM_VERSION_FULL "${YCM_VERSION_SHORT}~dev")
   else()
     # We assume that this is a release, there is not much that we can do if it's
     # not.
@@ -111,6 +103,7 @@ if(YCM_VERSION_DEBUG)
                YCM_VERSION_SHORT
                YCM_VERSION_MAJOR
                YCM_VERSION_MINOR
+               YCM_VERSION_FULL
                YCM_VERSION_PATCH
                YCM_VERSION_REVISION
                YCM_VERSION_DATE
@@ -122,4 +115,4 @@ if(YCM_VERSION_DEBUG)
   endforeach()
 endif()
 
-message(STATUS "YCM Version: ${YCM_VERSION} (${YCM_VERSION_SHORT})")
+message(STATUS "YCM Version: ${YCM_VERSION_FULL} (${YCM_VERSION_SHORT})")

--- a/tools/YCMBootstrapFetch.cmake
+++ b/tools/YCMBootstrapFetch.cmake
@@ -97,11 +97,4 @@ FetchContent_Declare(YCM
                      GIT_REPOSITORY https://github.com/${YCM_FETCHCONTENT_REPOSITORY}
                      GIT_TAG ${YCM_FETCHCONTENT_TAG})
 
-FetchContent_GetProperties(YCM)
-if(NOT YCM_POPULATED)
-    message(STATUS "Fetching YCM.")
-    FetchContent_Populate(YCM)
-    # Add YCM modules in CMAKE_MODULE_PATH
-    include(${ycm_SOURCE_DIR}/tools/UseYCMFromSource.cmake)
-endif()
-
+FetchContent_MakeAvailable(YCM)


### PR DESCRIPTION
* Permit to use FetchContent_MakeAvailable when YCM is used via FetchContent
* Switch `YCMBootstrapFetch` to use `FetchContent_MakeAvailable`, to avoid warning related to CMP0169 (fix https://github.com/robotology/ycm-cmake-modules/issues/453)
* Switch to define version variables in the standard CMake way, by passing VERSION to the `project` call. To do this, now `YCM_VERSION` is just major.minor.version, while the full version if required is provided in `YCM_VERSION_FULL`.
* Bump version to 0.17.0
* Deprecate `YCM_VERSION_REVISION`, `YCM_VERSION_DATE`, `YCM_VERSION_DATE_REVISION`, `YCM_VERSION_API`, `YCM_VERSION_SHORT`, `YCM_VERSION_SOURCE` and `YCM_VERSION_DIRTY`. This variable may be remove from YCM 0.18.0 .
