### PR TITLE
Fix support for consuming YCM via FetchContent_MakeAvailable and bump version to 0.17.1

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -24,9 +24,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
 
     - name: Dependencies

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -34,7 +34,7 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Compilation related dependencies
-        mamba install compilers make ninja pkg-config
+        conda install compilers make ninja pkg-config
 
     - name: CMake [Latest]
       shell: bash -l {0}
@@ -46,14 +46,14 @@ jobs:
       shell: bash -l {0}
       if: matrix.cmake_version != 'latest'
       run: |
-        mamba install cmake=${{ matrix.cmake_version }}
+        conda install cmake=${{ matrix.cmake_version }}
 
     - name: Windows-only Dependencies [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
         # Compilation related dependencies
-        mamba install vs2019_win-64
+        conda install vs2019_win-64
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-latest, windows-2019, macos-latest]
-        cmake_version: ["3.16","3.18","3.21","3.23","latest"]
+        cmake_version: ["3.18","3.21","3.23","latest"]
       fail-fast: false
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,16 @@
 
 
 cmake_minimum_required(VERSION 3.16)
-project(YCM VERSION 0.17.0 LANGUAGES NONE)
+project(YCM VERSION 0.17.1 LANGUAGES NONE)
 
 # Check if the project is the main project or included via FetchContent
 if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     # Project is included via FetchContent
     include(${CMAKE_CURRENT_SOURCE_DIR}/tools/UseYCMFromSource.cmake)
+    # Propagate relevant variables modified by UseYCMFromSource to who called add_subdirectory
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
+    set(__USEYCMFROMSOURCE_INCLUDED ${__USEYCMFROMSOURCE_INCLUDED} PARENT_SCOPE)
+    set(YCM_MODULE_DIR ${YCM_MODULE_DIR} PARENT_SCOPE)
     return()
 endif()
 


### PR DESCRIPTION
The support added in https://github.com/robotology/ycm-cmake-modules/pull/463 for consuming `YCM` via `FetchContent_MakeAvailable` had a bug, as `FetchContent_MakeAvailable` uses `add_subdirectory` under the hood to include a project, and `add_subdirectory` creates a new variable scope, so all variables set in it where not propagated to the context where  `FetchContent_MakeAvailable`. 

This PR fixes the issue by setting the used variable in the `PARENT_SCOPE`.