### PR TITLE
Fix calling ycm_ep_helper when YCM is consumed via find_package(YCM) and add test

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -104,7 +104,7 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        ctest --install .
+        cmake --install .
 
     - name: Integration test run a configure of the robotology-superbuild
       shell: bash -l {0}

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -113,4 +113,6 @@ jobs:
         cd testint
         git clone https://github.com/robotology/robotology-superbuild/
         cd robotology-superbuild/
+        git config --global user.name CI User
+        git config --global user.email ciuser@example.com
         cmake -Bbuild -S.

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -62,7 +62,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_IK:BOOL=OFF \
-              -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+              -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
 
     - name: Build [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -84,7 +84,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ..
 
     - name: Build [Windows]
       if: contains(matrix.os, 'windows')
@@ -99,3 +99,18 @@ jobs:
       run: |
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }} -E "Bootstrap"
+
+    - name: Install
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest --install .
+
+    - name: Integration test: run a configure of the robotology-superbuild
+      shell: bash -l {0}
+      run: |
+        mkdir testint
+        cd testint
+        git clone https://github.com/robotology/robotology-superbuild/
+        cd robotology-superbuild/
+        cmake -Bbuild -S.

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -106,7 +106,7 @@ jobs:
         cd build
         ctest --install .
 
-    - name: Integration test: run a configure of the robotology-superbuild
+    - name: Integration test run a configure of the robotology-superbuild
       shell: bash -l {0}
       run: |
         mkdir testint

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -16,6 +16,12 @@ set(YCM_MODULES AddInstallRPATHSupport.cmake
 _ycm_install(modules FILES ${YCM_MODULES}
                      DESTINATION "${YCM_INSTALL_MODULE_DIR}/modules")
 
+set(YCMEPHELPER_FILES YCMEPHelper/RepositoryInfo.txt.in
+                      YCMEPHelper/gitsafeclone.txt.in)
+
+_ycm_install(modules FILES ${YCMEPHELPER_FILES}
+                     DESTINATION "${YCM_INSTALL_MODULE_DIR}/modules/YCMEPHelper")
+
 # Print a warning if we are overriding some module from CMake
 foreach(_module IN LISTS YCM_MODULES)
   if(EXISTS "${CMAKE_ROOT}/Modules/${_module}")


### PR DESCRIPTION
The `ycm_ep_helper` used the two files `RepositoryInfo.txt.in` and `gitsafeclone.txt.in`, that however were not installed, so since YCM 0.16.7 and until YCM 0.18.0, `ycm_ep_helper`  worked fine (with CMake >= 3.22) only if YCM was bootstrapped or used via `FetchContent`, not if YCM was found via `find_package(YCM)`.