### PR TITLE
Fix "Compatibility with CMake < 3.10 will be removed" warnings in gitsafeclone.txt.in

### DIFF
--- a/modules/YCMEPHelper/gitsafeclone.txt.in
+++ b/modules/YCMEPHelper/gitsafeclone.txt.in
@@ -1,11 +1,11 @@
 # Based on https://gitlab.kitware.com/cmake/cmake/-/blob/v3.30.2/Modules/ExternalProject/gitclone.cmake.in
 # but with the modifications from https://github.com/robotology/ycm-cmake-modules/commit/582b5bca17c31ab511d6cba7b9a8111fc91e0e55
-# Furthermore, other modications were done to keep compatibility with 3.16
+# Furthermore, other modications were done to keep compatibility with 3.16 and avoid warnings in CMake >= 3.31
 
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 if(EXISTS "@gitclone_stampfile@" AND EXISTS "@gitclone_infofile@" AND
   "@gitclone_stampfile@" IS_NEWER_THAN "@gitclone_infofile@")


### PR DESCRIPTION
CMake started complaining for projects that requested 3.5 as cmake_minimum_required (see https://gitlab.kitware.com/cmake/cmake/-/commit/55778f5a16ffe1b67123a31f6b568f2f7c0a1f36), so it make sense to bump the `cmake_minimum_required` used in `gitsafeclone` to 3.16 (as the general one of YCM).

This will fix all the warnings:

~~~
CMake Deprecation Warning at /home/runner/work/robotology-superbuild/robotology-superbuild/b/src/OsqpEigen/CMakeFiles/YCMTmp/OsqpEigen-gitsafeclone.cmake:8 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
~~~

that occur when using a YCM-based superbuild with a recent CMake version.